### PR TITLE
Sticky event support

### DIFF
--- a/lib/event_bus.dart
+++ b/lib/event_bus.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:rxdart/subjects.dart';
 
 /// Dispatches events to listeners using the Dart [Stream] API. The [EventBus]
 /// enables decoupled applications. It allows objects to interact without
@@ -11,10 +12,16 @@ import 'dart:async';
 /// filter events.
 ///
 class EventBus {
-  StreamController _streamController;
+  late PublishSubject _sequentialStreamController;
+  late ReplaySubject _stickyStreamController;
+  final List<Object> _stickyEvents = [];
 
   /// Controller for the event bus stream.
-  StreamController get streamController => _streamController;
+  PublishSubject get sequentialStreamController => _sequentialStreamController;
+  ReplaySubject get stickyStreamController => _stickyStreamController;
+
+  /// List of available sticky events
+  List<Object> get stickyEvents => _stickyEvents;
 
   /// Creates an [EventBus].
   ///
@@ -22,15 +29,17 @@ class EventBus {
   /// during a [fire] call. If false (the default), the event will be passed to
   /// the listeners at a later time, after the code creating the event has
   /// completed.
-  EventBus({bool sync = false})
-      : _streamController = StreamController.broadcast(sync: sync);
+  EventBus({bool sync = false}) {
+    _sequentialStreamController = PublishSubject(sync: sync);
+    _stickyStreamController = ReplaySubject(sync: sync);
+  }
 
-  /// Instead of using the default [StreamController] you can use this constructor
-  /// to pass your own controller.
-  ///
-  /// An example would be to use an RxDart Subject as the controller.
-  EventBus.customController(StreamController controller)
-      : _streamController = controller;
+  // TODO: Someone do something with this please. Do we need this anymore? Do people actually use it?
+  // /// Instead of using the default [StreamController] you can use this constructor
+  // /// to pass your own controller.
+  // ///
+  // /// An example would be to use an RxDart Subject as the controller.
+  // EventBus.customController(StreamController controller) : _streamController = controller;
 
   /// Listens for events of Type [T] and its subtypes.
   ///
@@ -47,23 +56,82 @@ class EventBus {
   /// unpaused or canceled. So it's usually better to just cancel and later
   /// subscribe again (avoids memory leak).
   ///
-  Stream<T> on<T>() {
-    if (T == dynamic) {
-      return streamController.stream as Stream<T>;
-    } else {
-      return streamController.stream.where((event) => event is T).cast<T>();
+  Stream<T> on<T>({bool sticky = false}) {
+
+    // Handle sticky streams
+    if (sticky) {
+      if (T == dynamic) {
+        return _stickyStreamController.stream as Stream<T>;
+      } else {
+        return _stickyStreamController.stream.where((event) {
+          return (event is T) && _stickyEvents.contains(event);
+        }).cast<T>();
+      }
     }
+
+    // Handle sequential streams
+    if (T == dynamic) {
+      return _sequentialStreamController.stream as Stream<T>;
+    } else {
+      return _sequentialStreamController.stream.where((event) => event is T).cast<T>();
+    }
+
   }
 
   /// Fires a new event on the event bus with the specified [event].
   ///
-  void fire(event) {
-    streamController.add(event);
+  void fire(event, {bool sticky = false}) {
+    if (sticky) {
+      _addStickyEvent(event);
+    } else {
+      sequentialStreamController.add(event);
+    }
+  }
+
+  /// Sticky functions
+  ///
+  void _addStickyEvent(event) {
+
+    // Add the event to the list of events
+    _stickyEvents.add(event);
+
+    // Call any sticky listeners
+    _stickyStreamController.add(event);
+
+  }
+
+  void removeStickyEvent(event) {
+    _stickyEvents.remove(event);
+  }
+
+  void fireAllStickyEvents<T>() {
+    for (final event in _stickyEvents) {
+
+      // Try and call only events of a type
+      if (event is T) {
+        _stickyStreamController.add(event);
+      } else {
+        _stickyStreamController.add(event);
+      }
+
+    }
+  }
+
+  void removeAllStickyEvents<T>() {
+
+    // Remove all non-typed events
+    if (T == dynamic) {
+      _stickyEvents.clear();
+    } else {
+      _stickyEvents.removeWhere((event) => event is T);
+    }
+
   }
 
   /// Destroy this [EventBus]. This is generally only in a testing context.
   ///
   void destroy() {
-    _streamController.close();
+    _sequentialStreamController.close();
+    _stickyStreamController.close();
   }
 }


### PR DESCRIPTION
**NEEDS TESTS AND DOCUMENTATION**

Usage:

    // Declaration
    String exampleEvent = 'This is an event';
    EventBus eventBus = EventBus();
    StreamSubscription? yourEventListener;

    // Posting a sticky event
    eventBus.fire(exampleEvent, sticky: true);
    
    // ...sometime later
    // Handling the sticky event
    yourEventListener = eventBus.on<String>(sticky: true).listen((event) {
      print(event);

      eventBus.removeStickyEvent(event); 
      // If you do not remove the event, the next time the listener is initialized, it will fire again

    });

    // ...sometime later
    // Destroying the listener
    yourEventListener?.cancel();

The PR contains other functions like `removeAllStickyEvents` etc.

----

The developer experience is based on this Android project and should ideally be very similar:
https://github.com/greenrobot/EventBus